### PR TITLE
Format string numbers during confirmation

### DIFF
--- a/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
+++ b/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
@@ -13,7 +13,7 @@ import { DebtOrderEntity } from '../../../models';
 import * as Web3 from 'web3';
 import Dharma from '@dharmaprotocol/dharma.js';
 import { BigNumber } from 'bignumber.js';
-import { encodeUrlParams, debtOrderFromJSON, normalizeDebtOrder } from '../../../utils';
+import { encodeUrlParams, debtOrderFromJSON, normalizeDebtOrder, withCommas } from '../../../utils';
 const BitlyClient = require('bitly');
 
 interface Props {
@@ -193,7 +193,7 @@ class RequestLoanForm extends React.Component<Props, State> {
 	render() {
 		const confirmationModalContent = (
 			<span>
-				You are requesting a loan of <Bold>{this.state.principalAmount} {this.state.principalTokenSymbol}</Bold> at a <Bold>{this.state.interestRate}%</Bold> interest rate per the terms in the contract on the previous page. Are you sure you want to do this?
+				You are requesting a loan of <Bold>{withCommas(this.state.principalAmount)} {this.state.principalTokenSymbol}</Bold> at a <Bold>{this.state.interestRate}%</Bold> interest rate per the terms in the contract on the previous page. Are you sure you want to do this?
 			</span>
 		);
 		const descriptionContent = <span>Here's a quick description of what a debt order is and why you should request one.</span>;

--- a/src/utils/webUtils.ts
+++ b/src/utils/webUtils.ts
@@ -12,3 +12,7 @@ export const shortenString = (text: string) => {
 		return text;
 	}
 };
+
+export const withCommas = (input: number) => {
+	return input.toLocaleString();
+};


### PR DESCRIPTION
Should make it easier to read during confirmation

before:
<img width="507" alt="screen shot 2018-03-29 at 9 56 54 am" src="https://user-images.githubusercontent.com/36094097/38102427-0c105f16-3338-11e8-9ef8-b02cfe21a9aa.png">
after:
<img width="517" alt="screen shot 2018-03-29 at 10 00 09 am" src="https://user-images.githubusercontent.com/36094097/38102426-0bf7995e-3338-11e8-839c-fc785f392f5c.png">