### PR TITLE
Add link to chat in fill order footer, remove link to video temporarily

### DIFF
--- a/src/modules/FillLoan/FillLoanEmpty/index.tsx
+++ b/src/modules/FillLoan/FillLoanEmpty/index.tsx
@@ -53,8 +53,8 @@ class FillLoanEmpty extends React.Component<{}, State> {
 					/>
 					<Instructions>
 						<Title>Just getting started?</Title>
-						<StyledLink to="#" >FILLING DEBT ORDERS (VIDEO)</StyledLink>
-						<StyledLink to="/chat" >JOIN THE DHARMA CHAT</StyledLink>
+						{/*<StyledLink to="#" >FILLING DEBT ORDERS (VIDEO)</StyledLink>*/}
+						<StyledLink to="https://t.me/dharmalabs" >JOIN THE DHARMA CHAT</StyledLink>
 					</Instructions>
 				</MainWrapper>
 			</PaperLayout>


### PR DESCRIPTION
Updated temporarily to:

<img width="650" alt="screen shot 2018-03-29 at 10 22 57 am" src="https://user-images.githubusercontent.com/36094097/38103447-31b1395e-333b-11e8-8515-b370a77a4a1e.png">

Brendan might whip up a blog post for the other link.