### PR TITLE
add less confusing messages for when cannot connect to Kovan

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "reactstrap": "5.0.0-beta",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
+    "single-line-string": "^0.0.2",
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "styled-components": "^3.1.6",

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -34,9 +34,24 @@ import {
     SimpleInterestTermsContract,
 } from "@dharmaprotocol/contracts";
 
+const singleLineString = require("single-line-string");
+
 interface Props {
     store: any;
 }
+
+const WEB3_ERRORS = {
+    UNABLE_TO_FIND_ACCOUNTS: singleLineString`
+        Unable to find active account on current Ethereum network.  Make sure you are using
+        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
+        to the Kovan testnet, and that your account is unlocked.
+    `,
+    UNABLE_TO_FIND_CONTRACTS: singleLineString`
+        Unable to find the Dharma smart contracts on the current Ethereum network.  Make sure you are using
+        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
+        to the Kovan testnet, and that your account is unlocked.
+    `,
+};
 
 class AppRouter extends React.Component<Props, {}> {
     constructor(props: Props) {
@@ -63,7 +78,7 @@ class AppRouter extends React.Component<Props, {}> {
         const accounts = await promisify(web3.eth.getAccounts)();
 
         if (!accounts.length) {
-            dispatch(setError("Unable to find active account on current Ethereum network"));
+            dispatch(setError(WEB3_ERRORS.UNABLE_TO_FIND_ACCOUNTS));
             return;
         }
 
@@ -80,7 +95,7 @@ class AppRouter extends React.Component<Props, {}> {
                 networkId in SimpleInterestTermsContract.networks
             )
         ) {
-            dispatch(setError("Unable to connect to the blockchain"));
+            dispatch(setError(WEB3_ERRORS.UNABLE_TO_FIND_CONTRACTS));
             return;
         }
         const dharmaConfig = {


### PR DESCRIPTION
This PR introduces the following changes:

- presents more helpful messages when the app can't connect to Kovan for whatever reason