### PR TITLE
Populate make repayment with correct repayment token by default

### DIFF
--- a/src/components/MakeRepaymentModal/index.tsx
+++ b/src/components/MakeRepaymentModal/index.tsx
@@ -34,7 +34,10 @@ class MakeRepaymentModal extends React.Component<Props, State> {
         this.handleToggle = this.handleToggle.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
 
-        this.state = { repaymentAmount: new BigNumber(-1), repaymentTokenSymbol: "" };
+        this.state = {
+            repaymentAmount: new BigNumber(-1),
+            repaymentTokenSymbol: props.debtOrder.principalTokenSymbol,
+        };
     }
 
     onAmountChange(event: any) {
@@ -64,7 +67,7 @@ class MakeRepaymentModal extends React.Component<Props, State> {
     calculatePrincipalPlusInterest(
         principalAmount: BigNumber,
         interestRate: BigNumber,
-        numInstallments: BigNumber
+        numInstallments: BigNumber,
     ): BigNumber {
         const interestPaidPerInstallment = principalAmount.times(interestRate).div(100);
         const totalInterestPaid = interestPaidPerInstallment.times(numInstallments);
@@ -79,12 +82,17 @@ class MakeRepaymentModal extends React.Component<Props, State> {
         const totalAmountOwed = this.calculatePrincipalPlusInterest(
             debtOrder.principalAmount,
             debtOrder.interestRate,
-            debtOrder.termLength
+            debtOrder.termLength,
         );
 
         return (
             <div>
-                <Modal isOpen={this.props.modal} toggle={this.handleToggle} keyboard={false} backdrop={"static"}>
+                <Modal
+                    isOpen={this.props.modal}
+                    toggle={this.handleToggle}
+                    keyboard={false}
+                    backdrop={"static"}
+                >
                     <ModalHeader toggle={this.handleToggle}>{this.props.title}</ModalHeader>
                     <ModalBody>
                         <LoanSummary>
@@ -95,8 +103,7 @@ class MakeRepaymentModal extends React.Component<Props, State> {
                             </LoanSummaryItem>. You owe
                             <LoanSummaryItem>
                                 {" "}
-                                {totalAmountOwed.toString()} {debtOrder.principalTokenSymbol}
-                                {" "}
+                                {totalAmountOwed.toString()} {debtOrder.principalTokenSymbol}{" "}
                             </LoanSummaryItem>
                             in total, of which you've already repaid
                             <LoanSummaryItem>
@@ -105,7 +112,9 @@ class MakeRepaymentModal extends React.Component<Props, State> {
                             </LoanSummaryItem>.
                         </LoanSummary>
                         <h4>
-                            <b>How large of a repayment would you like to make, and in what token?</b>
+                            <b>
+                                How large of a repayment would you like to make, and in what token?
+                            </b>
                         </h4>
                         <div className="repayment-group">
                             <input
@@ -125,7 +134,7 @@ class MakeRepaymentModal extends React.Component<Props, State> {
                                 options={[
                                     { value: "REP", label: "REP (Augur REP)" },
                                     { value: "MKR", label: "MKR (Maker DAO)" },
-                                    { value: "ZRX", label: "ZRX (0x Protocol)" }
+                                    { value: "ZRX", label: "ZRX (0x Protocol)" },
                                 ]}
                                 onChange={this.onTokenSymbolChange}
                                 style={{ borderRadius: 0, height: 38, borderColor: "#000000" }}
@@ -135,7 +144,10 @@ class MakeRepaymentModal extends React.Component<Props, State> {
                     <ModalFooter>
                         <Row className="button-container">
                             <Col xs="12" md="6">
-                                <Button className="button secondary width-95" onClick={this.handleToggle}>
+                                <Button
+                                    className="button secondary width-95"
+                                    onClick={this.handleToggle}
+                                >
                                     {this.props.closeButtonText}
                                 </Button>
                             </Col>
@@ -147,7 +159,11 @@ class MakeRepaymentModal extends React.Component<Props, State> {
                                 >
                                     {this.props.submitButtonText}
                                     <div className="loading-spinner">
-                                        <ClipLoader size={12} color={"#ffffff"} loading={this.props.awaitingTx} />
+                                        <ClipLoader
+                                            size={12}
+                                            color={"#ffffff"}
+                                            loading={this.props.awaitingTx}
+                                        />
                                     </div>
                                 </Button>
                             </Col>

--- a/src/components/TradingPermissions/TradingPermissions.tsx
+++ b/src/components/TradingPermissions/TradingPermissions.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import { Toggle } from '../Toggle';
-import * as Web3 from 'web3';
-import Dharma from '@dharmaprotocol/dharma.js';
-import { BigNumber } from 'bignumber.js';
+import * as React from "react";
+import { Toggle } from "../Toggle";
+import * as Web3 from "web3";
+import Dharma from "@dharmaprotocol/dharma.js";
+import { BigNumber } from "bignumber.js";
 import {
     LoaderContainer,
     TradingPermissionsContainer,
@@ -11,13 +11,13 @@ import {
     TokenBalance,
     FaucetButton,
     ShowMoreButton,
-    Arrow
-} from './styledComponents';
-import { TokenEntity } from '../../models';
-const promisify = require('tiny-promisify');
-import { Collapse } from 'reactstrap';
-import { ClipLoader } from 'react-spinners';
-import { truncate } from 'src/utils/webUtils';
+    Arrow,
+} from "./styledComponents";
+import { TokenEntity } from "../../models";
+const promisify = require("tiny-promisify");
+import { Collapse } from "reactstrap";
+import { ClipLoader } from "react-spinners";
+import { truncate } from "src/utils/webUtils";
 
 interface Props {
     web3: Web3;
@@ -39,7 +39,7 @@ class TradingPermissions extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
-            collapse: false
+            collapse: false,
         };
         this.getTokenAllowance = this.getTokenAllowance.bind(this);
         this.updateProxyAllowanceAsync = this.updateProxyAllowanceAsync.bind(this);
@@ -65,7 +65,10 @@ class TradingPermissions extends React.Component<Props, State> {
         }
 
         const ownerAddress = accounts[0];
-        const tokenAllowance = await this.props.dharma.token.getProxyAllowanceAsync(tokenAddress, ownerAddress);
+        const tokenAllowance = await this.props.dharma.token.getProxyAllowanceAsync(
+            tokenAddress,
+            ownerAddress,
+        );
         return new BigNumber(tokenAllowance);
     }
 
@@ -96,13 +99,15 @@ class TradingPermissions extends React.Component<Props, State> {
 
             const tokenRegistry = await dharma.contracts.loadTokenRegistry();
             // TODO: get token tickers from dharma.js
-            const tokenSymbols = ['REP', 'MKR', 'ZRX'];
+            const tokenSymbols = ["REP", "MKR", "ZRX"];
 
             let allTokens: TokenEntity[] = [];
 
             for (let tokenSymbol of tokenSymbols) {
                 const address = await tokenRegistry.getTokenAddressBySymbol.callAsync(tokenSymbol);
-                const tradingPermitted = this.isAllowanceUnlimited(await this.getTokenAllowance(address));
+                const tradingPermitted = this.isAllowanceUnlimited(
+                    await this.getTokenAllowance(address),
+                );
                 let balance = await this.getTokenBalance(address);
                 // balance = tokenSymbol !== 'REP' ? new BigNumber(0) : balance;
                 allTokens.push({
@@ -110,13 +115,13 @@ class TradingPermissions extends React.Component<Props, State> {
                     tokenSymbol: tokenSymbol,
                     tradingPermitted,
                     balance,
-                    awaitingTransaction: false
+                    awaitingTransaction: false,
                 });
             }
 
             handleSetAllTokensTradingPermission(allTokens);
         } catch (e) {
-            this.props.handleSetError('Unable to get token data');
+            this.props.handleSetError("Unable to get token data");
             // console.log(e);
         }
     }
@@ -136,15 +141,20 @@ class TradingPermissions extends React.Component<Props, State> {
             if (selectedToken) {
                 let txHash;
                 if (tradingPermitted) {
-                    txHash = await dharma.token.setProxyAllowanceAsync(selectedToken.address, new BigNumber(0));
+                    txHash = await dharma.token.setProxyAllowanceAsync(
+                        selectedToken.address,
+                        new BigNumber(0),
+                    );
                 } else {
-                    txHash = await dharma.token.setUnlimitedProxyAllowanceAsync(selectedToken.address);
+                    txHash = await dharma.token.setUnlimitedProxyAllowanceAsync(
+                        selectedToken.address,
+                    );
                 }
 
                 await dharma.blockchain.awaitTransactionMinedAsync(txHash, 1000, 10000);
 
                 selectedToken.tradingPermitted = this.isAllowanceUnlimited(
-                    await this.getTokenAllowance(selectedToken.address)
+                    await this.getTokenAllowance(selectedToken.address),
                 );
 
                 this.props.handleToggleTokenTradingPermission(tokenAddress, !tradingPermitted);
@@ -152,10 +162,12 @@ class TradingPermissions extends React.Component<Props, State> {
 
             this.props.toggleTokenLoadingSpinner(tokenAddress, false);
         } catch (e) {
-            if (e.message.includes('Insufficient funds')) {
-                this.props.handleSetError('Insufficient ether in account to pay gas for transaction');
+            if (e.message.includes("Insufficient funds")) {
+                this.props.handleSetError(
+                    "Insufficient ether in account to pay gas for transaction",
+                );
             } else {
-                this.props.handleSetError('Unable to update token trading permission');
+                this.props.handleSetError("Unable to update token trading permission");
             }
 
             this.props.toggleTokenLoadingSpinner(tokenAddress, false);
@@ -164,15 +176,17 @@ class TradingPermissions extends React.Component<Props, State> {
     }
 
     isAllowanceUnlimited(tokenAllowance: BigNumber) {
-        return tokenAllowance.greaterThanOrEqualTo(new BigNumber(2).pow(32).minus(new BigNumber(1)));
+        return tokenAllowance.greaterThanOrEqualTo(
+            new BigNumber(2).pow(32).minus(new BigNumber(1)),
+        );
     }
 
-    async handleFaucet(tokenSymbol: string) {
+    async handleFaucet(tokenAddress: string) {
         const { dharma } = this.props;
 
         const accounts = await promisify(this.props.web3.eth.getAccounts)();
 
-        return this.props.handleFaucetRequest(tokenSymbol, accounts[0], dharma);
+        return this.props.handleFaucetRequest(tokenAddress, accounts[0], dharma);
     }
 
     showMore() {
@@ -189,8 +203,10 @@ class TradingPermissions extends React.Component<Props, State> {
 
         let count: number = 0;
         for (let token of tokens) {
-
-            const truncatedTokenBalance = truncate(web3.fromWei(token.balance, 'ether').toNumber(), 5);
+            const truncatedTokenBalance = truncate(
+                web3.fromWei(token.balance, "ether").toNumber(),
+                5,
+            );
 
             const tokenLabel = (
                 <div>
@@ -199,14 +215,18 @@ class TradingPermissions extends React.Component<Props, State> {
                         <TokenBalance>({truncatedTokenBalance})</TokenBalance>
                     ) : (
                         <FaucetButton
-                            onClick={e => this.handleFaucet(token.tokenSymbol)}
+                            onClick={(e) => this.handleFaucet(token.address)}
                             disabled={token.awaitingTransaction}
                         >
                             Faucet
                         </FaucetButton>
                     )}
                     <LoaderContainer>
-                        <ClipLoader size={12} color={'#1cc1cc'} loading={token.awaitingTransaction} />
+                        <ClipLoader
+                            size={12}
+                            color={"#1cc1cc"}
+                            loading={token.awaitingTransaction}
+                        />
                     </LoaderContainer>
                 </div>
             );
@@ -217,9 +237,11 @@ class TradingPermissions extends React.Component<Props, State> {
                         label={tokenLabel}
                         checked={token.tradingPermitted}
                         disabled={token.balance.gt(0) ? false : true}
-                        onChange={() => this.updateProxyAllowanceAsync(token.tradingPermitted, token.address)}
+                        onChange={() =>
+                            this.updateProxyAllowanceAsync(token.tradingPermitted, token.address)
+                        }
                         key={token.tokenSymbol}
-                    />
+                    />,
                 );
             } else {
                 tokenItemsMore.push(
@@ -228,9 +250,11 @@ class TradingPermissions extends React.Component<Props, State> {
                         label={tokenLabel}
                         checked={token.tradingPermitted}
                         disabled={token.balance.gt(0) ? false : true}
-                        onChange={() => this.updateProxyAllowanceAsync(token.tradingPermitted, token.address)}
+                        onChange={() =>
+                            this.updateProxyAllowanceAsync(token.tradingPermitted, token.address)
+                        }
                         key={token.tokenSymbol}
-                    />
+                    />,
                 );
             }
             count++;
@@ -238,16 +262,16 @@ class TradingPermissions extends React.Component<Props, State> {
 
         return (
             <TradingPermissionsContainer className={this.props.className}>
-                <TradingPermissionsTitle>{'Trading Permissions'}</TradingPermissionsTitle>
+                <TradingPermissionsTitle>{"Trading Permissions"}</TradingPermissionsTitle>
                 {tokenItems}
                 <Collapse isOpen={this.state.collapse}>{tokenItemsMore}</Collapse>
                 <ShowMoreButton onClick={this.showMore}>
-                    More{' '}
+                    More{" "}
                     <Arrow
                         src={
                             this.state.collapse
-                                ? require('../../assets/img/arrow_up_white.png')
-                                : require('../../assets/img/arrow_down_white.png')
+                                ? require("../../assets/img/arrow_up_white.png")
+                                : require("../../assets/img/arrow_down_white.png")
                         }
                     />
                 </ShowMoreButton>

--- a/src/components/TradingPermissions/TradingPermissionsContainer.tsx
+++ b/src/components/TradingPermissions/TradingPermissionsContainer.tsx
@@ -1,67 +1,74 @@
-import { connect } from 'react-redux';
-import { TradingPermissions } from './TradingPermissions';
-import { TokenEntity } from '../../models';
+import { connect } from "react-redux";
+import { TradingPermissions } from "./TradingPermissions";
+import { TokenEntity } from "../../models";
 import {
     setAllTokensTradingPermission,
     toggleTokenTradingPermission,
     toggleTokenLoadingSpinner,
-	setTokenBalance,
-} from './actions';
-import { setError } from '../../components/Toast/actions';
+    setTokenBalance,
+} from "./actions";
+import { setError } from "../../components/Toast/actions";
 
-import Dharma from '@dharmaprotocol/dharma.js';
-import { BigNumber } from 'bignumber.js';
+import Dharma from "@dharmaprotocol/dharma.js";
+import { BigNumber } from "bignumber.js";
 
 const mapStateToProps = (state: any) => {
     return {
         web3: state.web3Reducer.web3,
         dharma: state.dharmaReducer.dharma,
-        tokens: state.tokenReducer.tokens
+        tokens: state.tokenReducer.tokens,
     };
 };
 
 const mapDispatchToProps = (dispatch: any) => {
     return {
-        toggleTokenLoadingSpinner: (tokenAddress: string, loading: boolean) => dispatch(toggleTokenLoadingSpinner(tokenAddress, loading)),
-        handleSetAllTokensTradingPermission: (tokens: TokenEntity[]) => dispatch(setAllTokensTradingPermission(tokens)),
+        toggleTokenLoadingSpinner: (tokenAddress: string, loading: boolean) =>
+            dispatch(toggleTokenLoadingSpinner(tokenAddress, loading)),
+        handleSetAllTokensTradingPermission: (tokens: TokenEntity[]) =>
+            dispatch(setAllTokensTradingPermission(tokens)),
         handleToggleTokenTradingPermission: (tokenAddress: string, permission: boolean) =>
             dispatch(toggleTokenTradingPermission(tokenAddress, permission)),
         handleSetError: (errorMessage: string) => dispatch(setError(errorMessage)),
         handleFaucetRequest: (tokenAddress: string, userAddress: string, dharma: Dharma) => {
             dispatch(toggleTokenLoadingSpinner(tokenAddress, true));
 
-            const balance = Math.pow(10, 18);
+            const balance = 100 * Math.pow(10, 18);
 
             const faucetUrl = `https://faucet.dharma.io/dummy-tokens/${tokenAddress}/balance/${userAddress}`;
             const postData = {
-                method: 'post',
+                method: "post",
                 headers: {
-                    'Content-type': 'application/json; charset=UTF-8'
+                    "Content-type": "application/json; charset=UTF-8",
                 },
-                body: JSON.stringify({ balance: balance })
+                body: JSON.stringify({ balance: balance }),
             };
 
             fetch(faucetUrl, postData)
-                .then(res => {
+                .then((res) => {
                     return res.json();
                 })
-                .then(jsonBody => {
-                    if (!('txHash' in jsonBody)) {
-                        dispatch(setError('Unable to grant token balance via faucet'));
+                .then((jsonBody) => {
+                    if (!("txHash" in jsonBody)) {
+                        dispatch(setError("Unable to grant token balance via faucet"));
                     } else {
-						dharma.blockchain.awaitTransactionMinedAsync(jsonBody.txHash, 1000, 60000).then((res) => {
-							dispatch(toggleTokenLoadingSpinner(tokenAddress, false));
-							dispatch(setTokenBalance(tokenAddress, new BigNumber(10 ** 18)));
-						}).catch((err) => {
-							dispatch(setError('Unable to grant token balance via faucet'));
-						});
-					}
+                        dharma.blockchain
+                            .awaitTransactionMinedAsync(jsonBody.txHash, 1000, 60000)
+                            .then((res) => {
+                                dispatch(toggleTokenLoadingSpinner(tokenAddress, false));
+                                dispatch(setTokenBalance(tokenAddress, new BigNumber(balance)));
+                            })
+                            .catch((err) => {
+                                dispatch(setError("Unable to grant token balance via faucet"));
+                            });
+                    }
                 })
-                .catch(err => {
+                .catch((err) => {
                     dispatch(setError(err.message));
                 });
-        }
+        },
     };
 };
 
-export const TradingPermissionsContainer = connect(mapStateToProps, mapDispatchToProps)(TradingPermissions);
+export const TradingPermissionsContainer = connect(mapStateToProps, mapDispatchToProps)(
+    TradingPermissions,
+);

--- a/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
+++ b/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
@@ -16,7 +16,7 @@ import {
     ButtonContainer,
     DeclineButton,
     FillLoanButton,
-    LoaderContainer
+    LoaderContainer,
 } from "./styledComponents";
 import * as Web3 from "web3";
 import Dharma from "@dharmaprotocol/dharma.js";
@@ -62,12 +62,11 @@ class FillLoanEntered extends React.Component<Props, States> {
             interestRate: new BigNumber(0),
             termLength: new BigNumber(0),
             amortizationUnit: "",
-            issuanceHash: ""
+            issuanceHash: "",
         };
         this.confirmationModalToggle = this.confirmationModalToggle.bind(this);
         this.successModalToggle = this.successModalToggle.bind(this);
         this.handleFillOrder = this.handleFillOrder.bind(this);
-        this.validateFillOrder = this.validateFillOrder.bind(this);
         this.handleRedirect = this.handleRedirect.bind(this);
     }
 
@@ -92,13 +91,15 @@ class FillLoanEntered extends React.Component<Props, States> {
             delete debtOrder.principalTokenSymbol;
             this.setState({ debtOrder, description, principalTokenSymbol });
             if (debtOrder.termsContract && debtOrder.termsContractParameters) {
-                const fromDebtOrder = await dharma.adapters.simpleInterestLoan.fromDebtOrder(debtOrder);
+                const fromDebtOrder = await dharma.adapters.simpleInterestLoan.fromDebtOrder(
+                    debtOrder,
+                );
                 const issuanceHash = await dharma.order.getIssuanceHash(debtOrder);
                 this.setState({
                     interestRate: fromDebtOrder.interestRate,
                     termLength: fromDebtOrder.termLength,
                     amortizationUnit: fromDebtOrder.amortizationUnit,
-                    issuanceHash: issuanceHash
+                    issuanceHash: issuanceHash,
                 });
             }
         } catch (e) {
@@ -108,43 +109,8 @@ class FillLoanEntered extends React.Component<Props, States> {
 
     confirmationModalToggle() {
         this.setState({
-            confirmationModal: !this.state.confirmationModal
+            confirmationModal: !this.state.confirmationModal,
         });
-    }
-
-    validateFillOrder() {
-        const { debtOrder, principalTokenSymbol } = this.state;
-        const { tokens } = this.props;
-        const principalAmount = debtOrder.principalAmount || new BigNumber(0);
-        if (principalAmount.eq(0)) {
-            this.props.handleSetError("Invalid debt order");
-            return;
-        }
-
-        this.props.handleSetError("");
-        let found: boolean = false;
-        let error: boolean = false;
-        if (debtOrder.principalToken && tokens.length) {
-            for (let token of tokens) {
-                if (debtOrder.principalToken === token.address) {
-                    found = true;
-                    if (!token.tradingPermitted || token.balance.lt(principalAmount)) {
-                        error = true;
-                        break;
-                    }
-                }
-            }
-        } else {
-            error = true;
-        }
-        if (!found) {
-            error = true;
-        }
-        if (error) {
-            this.props.handleSetError(principalTokenSymbol + " is currently disabled for trading");
-            return;
-        }
-        this.confirmationModalToggle();
     }
 
     async handleFillOrder() {
@@ -167,7 +133,7 @@ class FillLoanEntered extends React.Component<Props, States> {
             if (errorLogs.length) {
                 this.props.handleSetError(errorLogs[0]);
                 this.setState({
-                    confirmationModal: false
+                    confirmationModal: false,
                 });
             } else {
                 this.props.handleFillDebtOrder(issuanceHash);
@@ -176,7 +142,7 @@ class FillLoanEntered extends React.Component<Props, States> {
         } catch (e) {
             this.props.handleSetError(e.message);
             this.setState({
-                confirmationModal: false
+                confirmationModal: false,
             });
         }
     }
@@ -184,7 +150,7 @@ class FillLoanEntered extends React.Component<Props, States> {
     successModalToggle() {
         this.setState({
             confirmationModal: false,
-            successModal: !this.state.successModal
+            successModal: !this.state.successModal,
         });
     }
 
@@ -200,7 +166,7 @@ class FillLoanEntered extends React.Component<Props, States> {
             termLength,
             amortizationUnit,
             principalTokenSymbol,
-            issuanceHash
+            issuanceHash,
         } = this.state;
 
         const leftInfoItems = [
@@ -208,27 +174,30 @@ class FillLoanEntered extends React.Component<Props, States> {
                 title: "Principal",
                 content: debtOrder.principalAmount
                     ? debtOrder.principalAmount.toNumber() + " " + principalTokenSymbol
-                    : ""
+                    : "",
             },
             {
                 title: "Term Length",
-                content: termLength && amortizationUnit ? termLength.toNumber() + " " + amortizationUnit : "-"
-            }
+                content:
+                    termLength && amortizationUnit
+                        ? termLength.toNumber() + " " + amortizationUnit
+                        : "-",
+            },
         ];
         const rightInfoItems = [
             { title: "Interest Rate", content: interestRate.toNumber() + "%" },
             {
                 title: "Installment Frequency",
-                content: amortizationUnit ? amortizationUnitToFrequency(amortizationUnit) : "-"
-            }
+                content: amortizationUnit ? amortizationUnitToFrequency(amortizationUnit) : "-",
+            },
         ];
-        const leftInfoItemRows = leftInfoItems.map(item => (
+        const leftInfoItemRows = leftInfoItems.map((item) => (
             <InfoItem key={item.title}>
                 <Title>{item.title}</Title>
                 <Content>{item.content}</Content>
             </InfoItem>
         ));
-        const rightInfoItemRows = rightInfoItems.map(item => (
+        const rightInfoItemRows = rightInfoItems.map((item) => (
             <InfoItem key={item.title}>
                 <Title>{item.title}</Title>
                 <Content>{item.content}</Content>
@@ -237,17 +206,19 @@ class FillLoanEntered extends React.Component<Props, States> {
 
         const confirmationModalContent = (
             <span>
-                You will fill this debt order <Bold>{shortenString(issuanceHash)}</Bold>. This operation will debit{" "}
+                You will fill this debt order <Bold>{shortenString(issuanceHash)}</Bold>. This
+                operation will debit{" "}
                 <Bold>
-                    {debtOrder.principalAmount && debtOrder.principalAmount.toNumber()} {principalTokenSymbol}
+                    {debtOrder.principalAmount && debtOrder.principalAmount.toNumber()}{" "}
+                    {principalTokenSymbol}
                 </Bold>{" "}
                 from your account.
             </span>
         );
         const descriptionContent = (
             <span>
-                Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look fair to you, fill
-                the loan and your transaction will be completed.
+                Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look
+                fair to you, fill the loan and your transaction will be completed.
             </span>
         );
         return (
@@ -268,7 +239,10 @@ class FillLoanEntered extends React.Component<Props, States> {
                         <Link to="/fill">
                             <DeclineButton>Decline</DeclineButton>
                         </Link>
-                        <FillLoanButton onClick={this.validateFillOrder} disabled={this.state.awaitingTransaction}>
+                        <FillLoanButton
+                            onClick={this.confirmationModalToggle}
+                            disabled={this.state.awaitingTransaction}
+                        >
                             Fill Loan
                         </FillLoanButton>
                     </ButtonContainer>
@@ -289,7 +263,9 @@ class FillLoanEntered extends React.Component<Props, States> {
                         onToggle={this.confirmationModalToggle}
                         onSubmit={this.handleFillOrder}
                         closeButtonText="Cancel"
-                        submitButtonText={this.state.awaitingTransaction ? "Filling order..." : "Fill Order"}
+                        submitButtonText={
+                            this.state.awaitingTransaction ? "Filling order..." : "Fill Order"
+                        }
                     />
                     <SuccessModal
                         modal={this.state.successModal}


### PR DESCRIPTION
This PR introduces the following changes:

- Fixes bug introduced in to faucet endpoint
- Removes redundant order fill validations, given that dharma.js does these same checks for us
- By default, populates the make repayment modal with the correct token needed for repayment